### PR TITLE
ラベルを剥がすロジックの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Googleの[Apps script](https://workspace.google.co.jp/intl/ja/products/apps-script/)を使って、Gmailを自動で分類しTODOリスト化するプログラムです。ローカル環境は node か bun、静的型付けのためにTypeScriptを使用、GASの管理には[clasp](https://github.com/google/clasp)を使っています。
 
-スプレッドシート、またはJira Softwareのプロジェクトに、メールの内容をTODOとして登録することを想定しています。
+スプレッドシート、Notion、またはJira Softwareのプロジェクトに、メールの内容をTODOとして登録することを想定しています。
 
 ## 使い方
 

--- a/src/NotionActions.ts
+++ b/src/NotionActions.ts
@@ -131,6 +131,119 @@ export class NotionActions {
       children: [
         {
           object: "block",
+          type: "bulleted_list_item",
+          bulleted_list_item: {
+            rich_text: [
+              {
+                type: "text",
+                text: {
+                  content: `[FROM] | ${json.from}`,
+                },
+                annotations: {
+                  bold: true,
+                  code: true,
+                },
+              },
+            ],
+          },
+        },
+        {
+          object: "block",
+          type: "bulleted_list_item",
+          bulleted_list_item: {
+            rich_text: [
+              {
+                type: "text",
+                text: {
+                  content: `[TO] | ${json.to}`,
+                },
+                annotations: {
+                  bold: true,
+                  code: true,
+                },
+              },
+            ],
+          },
+        },
+        {
+          object: "block",
+          type: "bulleted_list_item",
+          bulleted_list_item: {
+            rich_text: [
+              {
+                type: "text",
+                text: {
+                  content: `[RECEIVED_AT] | ${json.receivedAt}`,
+                },
+                annotations: {
+                  bold: true,
+                  code: true,
+                },
+              },
+            ],
+          },
+        },
+        {
+          object: "block",
+          type: "bulleted_list_item",
+          bulleted_list_item: {
+            rich_text: [
+              {
+                type: "text",
+                text: {
+                  content: `[SERCH_QUERY] | ${json.searchQuery}`,
+                },
+                annotations: {
+                  bold: true,
+                  code: true,
+                },
+              },
+            ],
+          },
+        },
+        {
+          object: "block",
+          type: "bulleted_list_item",
+          bulleted_list_item: {
+            rich_text: [
+              {
+                type: "text",
+                text: {
+                  content: `[MESSAGE_ID] | ${json.messageId}`,
+                },
+                annotations: {
+                  bold: true,
+                  code: true,
+                },
+              },
+            ],
+          },
+        },
+        {
+          object: "block",
+          type: "bulleted_list_item",
+          bulleted_list_item: {
+            rich_text: [
+              {
+                type: "text",
+                text: {
+                  content: `[THREAD_ID] | ${json.threadId}`,
+                },
+                annotations: {
+                  bold: true,
+                  code: true,
+                },
+              },
+            ],
+          },
+        },
+        {
+          object: "block",
+          type: "divider",
+          divider: {},
+        },
+        {
+          object: "block",
           type: "paragraph",
           paragraph: {
             rich_text: [

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,4 +55,15 @@ function main() {
   //  * Spreadsheetに登録
   //  */
   // SpreadsheetActions.register(ENV.SPREADSHEET_BOOK_ID, jsonDtoArray);
+
+  /**
+   * タスク登録済みのスレッドからラベルを外す。
+   */
+  if (threads.length) {
+    threads.forEach((thread) => {
+      const label = GmailApp.getUserLabelByName(ENV.TASK_LABEL);
+      label.removeFromThread(thread);
+    });
+    Logger.log(`ラベル削除:${ENV.TASK_LABEL} -> ${threads.length}件`);
+  }
 }


### PR DESCRIPTION
- docs(readme.md): readmeの修正
- fix(main.ts): スレッドからラベルを削除するロジックを追加
- fix(notionactions.ts): 登録するメール情報の追加
タスクに登録済みのスレッドから識別用のラベルを取り除くロジックを追加。またNotionに登録するメールの情報を追加。
